### PR TITLE
parse_datetime for Japanese 

### DIFF
--- a/lib/ofx-parser.rb
+++ b/lib/ofx-parser.rb
@@ -56,10 +56,10 @@ module OfxParser
     # Returns a DateTime object. Milliseconds (XXX) are ignored.
     def self.parse_datetime(date)
       if /\A\s*
-          (\d{4})(\d{2})(\d{2})       ?# YYYYMMDD            1,2,3
-          (?:(\d{2})(\d{2})(\d{2}))?  ?# HHMMSS  - optional  4,5,6
-          (?:\.(\d{3}))?              ?# .XXX    - optional  7
-          (?:\[(-?\d+)\:\w{3}\])?     ?# [-n:TZ] - optional  8,9
+          (\d{4})(\d{2})(\d{2})           ?# YYYYMMDD            1,2,3
+          (?:(\d{2})(\d{2})(\d{2}))?      ?# HHMMSS  - optional  4,5,6
+          (?:\.(\d{3}))?                  ?# .XXX    - optional  7
+          (?:\[([-+]?[\.\d]+)\:\w{3}\])?  ?# [-n:TZ] - optional  8,9
           \s*\z/ix =~ date
         year = $1.to_i
         mon = $2.to_i

--- a/test/test_ofx_parser.rb
+++ b/test/test_ofx_parser.rb
@@ -39,6 +39,7 @@ class OfxParserTest < Test::Unit::TestCase
 
   def test_parse_datetime
     assert_equal DateTime.civil(2007, 6, 22, 19, 0, 0, Rational(-5,24)), @parser.parse_datetime('20070622190000.200[-5:CDT]')
+    assert_equal DateTime.civil(2007, 6, 22, 19, 0, 0, Rational(9,24)), @parser.parse_datetime('20070622190000.200[+9.0:JST]')
     assert_equal DateTime.civil(2007, 6, 22), @parser.parse_datetime('20070622')
     assert_equal DateTime.civil(2007, 6, 22, 19, 0, 0), @parser.parse_datetime('20070622190000')
     assert_equal DateTime.civil(2007, 6, 22, 19, 0, 0), @parser.parse_datetime('20070622190000.200')


### PR DESCRIPTION
In Japan, the timezone is written like [+9.0:JST] .
but now, parse_datetime is not support "+" and "x.x" patern. 

Please see my patch.
