### PR TITLE
Parse the check number when it is present, rather than in case of checks...

### DIFF
--- a/lib/ofx-parser.rb
+++ b/lib/ofx-parser.rb
@@ -185,7 +185,7 @@ module OfxParser
       transaction.payee = (t/"PAYEE").inner_text + (t/"NAME").inner_text
       transaction.memo = (t/"MEMO").inner_text
       transaction.sic = (t/"SIC").inner_text
-      transaction.check_number = (t/"CHECKNUM").inner_text if transaction.type == :CHECK
+      transaction.check_number = (t/"CHECKNUM").inner_text unless (t/"CHECKNUM").inner_text.empty?
       transaction
     end
 

--- a/test/fixtures/banking.ofx.sgml
+++ b/test/fixtures/banking.ofx.sgml
@@ -75,6 +75,15 @@ NEWFILEUID:NONE
             <NAME>ATM DEPOSIT US BANK ANYTOWNAS</NAME>
             <MEMO>Download from usbank.com. US BANK ANYTOWN ASUS1</MEMO>
           </STMTTRN>
+          <STMTTRN>
+            <TRNTYPE>DEBIT</TRNTYPE>
+            <DTPOSTED>20070608120000.000</DTPOSTED>
+            <TRNAMT>-111.12</TRNAMT>
+            <FITID>22222B</FITID>
+            <CHECKNUM>0000009612</CHECKNUM>
+            <NAME>GENERIC PAYMENT</NAME>
+            <MEMO>Download from San Diego Trust Bank</MEMO>
+          </STMTTRN>
         </BANKTRANLIST>
         <LEDGERBAL>
           <BALAMT>1234.09</BALAMT>

--- a/test/test_ofx_parser.rb
+++ b/test/test_ofx_parser.rb
@@ -189,7 +189,7 @@ class OfxParserTest < Test::Unit::TestCase
     assert_equal DateTime.civil(2007,6,22,19,0,0,Rational(-5, 24)), statement.end_date
 
     transactions = statement.transactions
-    assert_equal 4, transactions.size
+    assert_equal 5, transactions.size
 
     assert_equal :PAYMENT, transactions[0].type
     assert_equal OfxParser::Transaction::TYPE[:PAYMENT], transactions[0].type_desc
@@ -238,6 +238,18 @@ class OfxParserTest < Test::Unit::TestCase
     assert_equal nil, transactions[3].sic_desc
     assert_equal 'ATM DEPOSIT US BANK ANYTOWNAS', transactions[3].payee
     assert_equal 'Download from usbank.com. US BANK ANYTOWN ASUS1', transactions[3].memo
+
+    assert_equal :DEBIT, transactions[4].type
+    assert_equal OfxParser::Transaction::TYPE[:DEBIT], transactions[4].type_desc
+    assert_equal DateTime.civil(2007,6,8,12,0,0), transactions[4].date
+    assert_equal '-111.12', transactions[4].amount
+    assert_equal -11112, transactions[4].amount_in_pennies
+    assert_equal '22222B', transactions[4].fit_id
+    assert_equal '0000009612', transactions[4].check_number
+    assert_equal nil, transactions[4].sic
+    assert_equal nil, transactions[4].sic_desc
+    assert_equal 'GENERIC PAYMENT', transactions[4].payee
+    assert_equal 'Download from San Diego Trust Bank', transactions[4].memo
 
     # Test Bank Account #2 ---------------------------------------------------
 


### PR DESCRIPTION
.... This handles cases when banks mislabel checks as generic debits, and the spec does not specify that only checks may have check numbers.

I ran into a problem parsing San Diego Bank's checks; this solves the issue.
