### PR TITLE
Fixes bug where decimal amounts e.g. ".79" would be treated as "79"...

### DIFF
--- a/lib/ofx.rb
+++ b/lib/ofx.rb
@@ -17,7 +17,7 @@ module OfxParser
     def pennies_for(amount)
       return nil if amount == ""
       int, fraction = amount.scan(/\d+/)
-      int, fraction = 0, int if amount.match(/-?\./)
+      int, fraction = 0, int if amount.match(/^-?\./)
       i = (fraction.to_s.strip =~ /[1-9]/) ? "#{int}#{fraction[0,2]}".to_i : int.to_i * 100
       amount =~ /^\s*-\s*\d+/ ? -i : i
     end

--- a/lib/ofx.rb
+++ b/lib/ofx.rb
@@ -11,14 +11,17 @@ module OfxParser
 
   module MonetarySupport
     # Returns pennies for a given string amount, i.e:
+    #  '-.45' => -45
     #  '-123.45' => -12345
     #  '123' => 12300
     def pennies_for(amount)
       return nil if amount == ""
       int, fraction = amount.scan(/\d+/)
+      int, fraction = 0, int if amount.match(/-?\./)
       i = (fraction.to_s.strip =~ /[1-9]/) ? "#{int}#{fraction[0,2]}".to_i : int.to_i * 100
       amount =~ /^\s*-\s*\d+/ ? -i : i
     end
+
 
     def original_method(meth) #:nodoc:
       meth.to_s.sub('_in_pennies','').to_sym rescue nil

--- a/lib/ofx.rb
+++ b/lib/ofx.rb
@@ -19,7 +19,7 @@ module OfxParser
       int, fraction = amount.scan(/\d+/)
       int, fraction = 0, int if amount.match(/^-?\./)
       i = (fraction.to_s.strip =~ /[1-9]/) ? "#{int}#{fraction[0,2]}".to_i : int.to_i * 100
-      amount =~ /^\s*-\s*\d+/ ? -i : i
+      amount =~ /^\s*-\s*.?\d+/ ? -i : i
     end
 
 

--- a/test/fixtures/banking.ofx.sgml
+++ b/test/fixtures/banking.ofx.sgml
@@ -45,7 +45,7 @@ NEWFILEUID:NONE
           <STMTTRN>
             <TRNTYPE>PAYMENT</TRNTYPE>
             <DTPOSTED>20070606120000.000</DTPOSTED>
-            <TRNAMT>-.11</TRNAMT>
+            <TRNAMT>-11.11</TRNAMT>
             <FITID>11111111 22</FITID>
             <NAME>WEB AUTHORIZED PMT FOO INC</NAME>
             <MEMO>Download from usbank.com. FOO INC</MEMO>

--- a/test/fixtures/banking.ofx.sgml
+++ b/test/fixtures/banking.ofx.sgml
@@ -45,7 +45,7 @@ NEWFILEUID:NONE
           <STMTTRN>
             <TRNTYPE>PAYMENT</TRNTYPE>
             <DTPOSTED>20070606120000.000</DTPOSTED>
-            <TRNAMT>-11.11</TRNAMT>
+            <TRNAMT>-.11</TRNAMT>
             <FITID>11111111 22</FITID>
             <NAME>WEB AUTHORIZED PMT FOO INC</NAME>
             <MEMO>Download from usbank.com. FOO INC</MEMO>

--- a/test/test_ofx_parser.rb
+++ b/test/test_ofx_parser.rb
@@ -117,7 +117,7 @@ class OfxParserTest < MiniTest::Unit::TestCase
     assert_equal :PAYMENT, transactions[0].type
     assert_equal OfxParser::Transaction::TYPE[:PAYMENT], transactions[0].type_desc
     assert_kind_of DateTime, transactions[0].date
-    assert_equal '-.11', transactions[0].amount
+    assert_equal '-11.11', transactions[0].amount
     assert_equal(-1111, transactions[0].amount_in_pennies)
     assert_equal '11111111 22', transactions[0].fit_id
     assert_equal nil, transactions[0].check_number
@@ -460,6 +460,7 @@ class OfxParserTest < MiniTest::Unit::TestCase
       '1' => 100,
       '1.0' => 100,
       '-1.0' => -100,
+      '-.11' => -11,
       '' => nil
     }
 

--- a/test/test_ofx_parser.rb
+++ b/test/test_ofx_parser.rb
@@ -1,5 +1,6 @@
 require 'minitest/autorun'
 require 'ofx-parser'
+require 'pry'
 
 class OfxParserTest < MiniTest::Unit::TestCase
 
@@ -116,7 +117,7 @@ class OfxParserTest < MiniTest::Unit::TestCase
     assert_equal :PAYMENT, transactions[0].type
     assert_equal OfxParser::Transaction::TYPE[:PAYMENT], transactions[0].type_desc
     assert_kind_of DateTime, transactions[0].date
-    assert_equal '-11.11', transactions[0].amount
+    assert_equal '-.11', transactions[0].amount
     assert_equal(-1111, transactions[0].amount_in_pennies)
     assert_equal '11111111 22', transactions[0].fit_id
     assert_equal nil, transactions[0].check_number


### PR DESCRIPTION
… and converted to 7900 pennies
